### PR TITLE
Document signing contract, rename errors to ErrFoo, update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: no-commit-to-branch
       - id: check-yaml
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.55.2
+    rev: v2.11.4
     hooks:
       - id: golangci-lint-full

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Go Jose
-Package go_jose is a set of crypto signer implementations for common algorithms
+A Go implementation of the JOSE suite of specifications — JWS ([RFC 7515](https://www.rfc-editor.org/rfc/rfc7515)), JWA ([RFC 7518](https://www.rfc-editor.org/rfc/rfc7518)), JWK ([RFC 7517](https://www.rfc-editor.org/rfc/rfc7517)), and JWT ([RFC 7519](https://www.rfc-editor.org/rfc/rfc7519)).
 
 ## Requirements
 - Go 1.21 or higher
@@ -68,14 +68,20 @@ The `GetSignerFromPrivateKey` method can also be used. This takes in an algorith
 signer, err := jose.GetSignerFromPrivateKey(model.ES256, privateKey)
 ```
 
-## SignerOpts
-This package includes a SignerOpts implementation as shown below:
+## Signing Contract
+The `Sign` method follows JOSE conventions per RFC 7518 rather than Go's `crypto.Signer` contract. It supports two modes:
+
+- **JOSE mode** (`opts == nil` or `opts.HashFunc() == 0`): pass the raw JWS Signing Input — the signer hashes it internally using the algorithm's designated hash. This is the expected usage for JWS operations.
+- **Pre-hashed mode** (`opts.HashFunc() != 0`): pass an already-hashed digest — the signer skips internal hashing. This supports interoperability with callers following Go's `crypto.Signer` convention.
+
+A `SignerOpts` implementation is provided:
 ```go
 type SignerOpts struct {
 	Hash crypto.Hash
 }
 ```
-This is provided for simplicity and usage is in line with that specified by the `crypto.Signer` interface. If a hash isn't specified, no hashing is assumed as having occured and the signing algorithms will perform their own hashing.
+
+`ValidateSignature` always expects the raw signing input (not pre-hashed) and hashes internally.
 
 ## Validators
 In addition to the packaged signers, a validator type is also included for each algorithm. This can be constructed in one of two ways:
@@ -106,7 +112,7 @@ valid, err := validator.ValidateSignature(digest, signature)
 
 Finally, validators expose their PublicKey with the `Public()` method
 ```go
-validator, err :- jose.GetValidator(model.ES256, publicKey)
+validator, err := jose.GetValidator(model.ES256, publicKey)
 pk := validator.Public()
 ```
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -270,7 +270,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*ecdsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*ecdsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -283,7 +283,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - curve should be P-256, was P-521" {
+				if err.Error() != "invalid private key: curve should be P-256, was P-521" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -296,7 +296,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*ecdsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*ecdsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -309,7 +309,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - curve should be P-384, was P-521" {
+				if err.Error() != "invalid private key: curve should be P-384, was P-521" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -322,7 +322,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*ecdsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*ecdsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -335,7 +335,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - curve should be P-521, was P-256" {
+				if err.Error() != "invalid private key: curve should be P-521, was P-256" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -348,7 +348,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*rsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*rsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -361,7 +361,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*rsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*rsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -374,7 +374,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*rsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*rsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -387,7 +387,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*rsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*rsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -400,7 +400,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*rsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*rsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -413,7 +413,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "invalid key provided - should be instance of `*rsa.Privatekey`" {
+				if err.Error() != "invalid private key: should be instance of `*rsa.Privatekey`" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -426,7 +426,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "HMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function" {
+				if err.Error() != "unsupported algorithm: HMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -439,7 +439,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "HMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function" {
+				if err.Error() != "unsupported algorithm: HMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},
@@ -452,7 +452,7 @@ func TestGetSignerFromPrivateKey(t *testing.T) {
 				if err == nil {
 					t.Fatal("error should be thrown when wrong key provided")
 				}
-				if err.Error() != "HMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function" {
+				if err.Error() != "unsupported algorithm: HMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function" {
 					t.Errorf("wrong error returned: %s", err.Error())
 				}
 			},

--- a/error/error.go
+++ b/error/error.go
@@ -2,8 +2,8 @@ package error
 
 import "errors"
 
-var InvalidPublicKey = errors.New("")
-var InvalidPrivateKey = errors.New("")
-var InvalidSignature = errors.New("")
-var UnsupportedAlgorithm = errors.New("")
-var SigningError = errors.New("")
+var ErrInvalidPublicKey = errors.New("invalid public key: ")
+var ErrInvalidPrivateKey = errors.New("invalid private key: ")
+var ErrInvalidSignature = errors.New("invalid signature")
+var ErrUnsupportedAlgorithm = errors.New("unsupported algorithm: ")
+var ErrSigning = errors.New("signing error: ")

--- a/internal/algorithms/common/common.go
+++ b/internal/algorithms/common/common.go
@@ -56,17 +56,17 @@ func NewECDSAPublicKeyFromJson(publicKeyJson []byte, curve elliptic.Curve) (*ecd
 	var publicKey ECDSAPublicKey
 	err := json.Unmarshal(publicKeyJson, &publicKey)
 	if err != nil {
-		return nil, fmt.Errorf("%wprovided public key json isn't a valid ecdsa public key: %s", jose_errors.InvalidPublicKey, err.Error())
+		return nil, fmt.Errorf("%wprovided public key json isn't a valid ecdsa public key: %s", jose_errors.ErrInvalidPublicKey, err.Error())
 	}
 
 	xBytes, err := base64.RawURLEncoding.DecodeString(publicKey.X)
 	if err != nil {
-		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.InvalidPublicKey, err.Error())
+		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.ErrInvalidPublicKey, err.Error())
 	}
 
 	yBytes, err := base64.RawURLEncoding.DecodeString(publicKey.Y)
 	if err != nil {
-		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.InvalidPublicKey, err.Error())
+		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.ErrInvalidPublicKey, err.Error())
 	}
 
 	pk := &ecdsa.PublicKey{
@@ -212,17 +212,17 @@ func NewRSAPublicKeyFromJson(publicKeyJson []byte) (*rsa.PublicKey, error) {
 	var publicKey RSAPublicKey
 	err := json.Unmarshal(publicKeyJson, &publicKey)
 	if err != nil {
-		return nil, fmt.Errorf("%wprovided public key json isn't a valid rsa public key: %s", jose_errors.InvalidPublicKey, err.Error())
+		return nil, fmt.Errorf("%wprovided public key json isn't a valid rsa public key: %s", jose_errors.ErrInvalidPublicKey, err.Error())
 	}
 
 	nBytes, err := base64.RawURLEncoding.DecodeString(publicKey.N)
 	if err != nil {
-		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.InvalidPublicKey, err.Error())
+		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.ErrInvalidPublicKey, err.Error())
 	}
 
 	eBytes, err := base64.RawURLEncoding.DecodeString(publicKey.E)
 	if err != nil {
-		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.InvalidPublicKey, err.Error())
+		return nil, fmt.Errorf("%werror decoding provided public key: %s", jose_errors.ErrInvalidPublicKey, err.Error())
 	}
 
 	pk := &rsa.PublicKey{
@@ -377,7 +377,7 @@ func JwkFromRSAPrivateKey(privateKey *rsa.PrivateKey) map[string]any {
 
 func ExtractRSFromSignature(signature []byte, keySize int) (*big.Int, *big.Int, error) {
 	if len(signature) != keySize {
-		return nil, nil, fmt.Errorf("%wsignature should be %d bytes for given algorithm", jose_errors.InvalidSignature, keySize)
+		return nil, nil, fmt.Errorf("%wsignature should be %d bytes for given algorithm", jose_errors.ErrInvalidSignature, keySize)
 	}
 	rb := signature[:keySize/2]
 	sb := signature[keySize/2:]
@@ -391,7 +391,7 @@ func ExtractRSFromSignature(signature []byte, keySize int) (*big.Int, *big.Int, 
 func EllipticCurveSign(rand io.Reader, pk ecdsa.PrivateKey, digest []byte, keySize int) ([]byte, error) {
 	r, s, err := ecdsa.Sign(rand, &pk, digest)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to sign token: %s", jose_errors.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to sign token: %s", jose_errors.ErrSigning, err.Error())
 	}
 
 	sigBytes := make([]byte, keySize)
@@ -405,7 +405,7 @@ func EllipticCurveSign(rand io.Reader, pk ecdsa.PrivateKey, digest []byte, keySi
 func RsaPkcs1Sign(rand io.Reader, pk rsa.PrivateKey, digest []byte, hash crypto.Hash) ([]byte, error) {
 	s, err := rsa.SignPKCS1v15(rand, &pk, hash, digest)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to sign token: %s", jose_errors.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to sign token: %s", jose_errors.ErrSigning, err.Error())
 	}
 	return s, nil
 }
@@ -417,7 +417,7 @@ func RsaPSSSign(rand io.Reader, pk rsa.PrivateKey, digest []byte, hash crypto.Ha
 	}
 	s, err := rsa.SignPSS(rand, &pk, hash, digest, opts)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to sign token: %s", jose_errors.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to sign token: %s", jose_errors.ErrSigning, err.Error())
 	}
 	return s, nil
 }

--- a/internal/algorithms/es256/ES256.go
+++ b/internal/algorithms/es256/ES256.go
@@ -29,7 +29,7 @@ func NewSigner() (*Signer, error) {
 	curve := elliptic.P256()
 	pk, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.ES256,
@@ -40,10 +40,10 @@ func NewSigner() (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	ecdsaPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*ecdsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*ecdsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	if ecdsaPrivateKey.Curve.Params().Name != curveName {
-		return nil, fmt.Errorf("%winvalid key provided - curve should be %s, was %s", e.InvalidPrivateKey, curveName, ecdsaPrivateKey.Curve.Params().Name)
+		return nil, fmt.Errorf("%wcurve should be %s, was %s", e.ErrInvalidPrivateKey, curveName, ecdsaPrivateKey.Curve.Params().Name)
 	}
 	return &Signer{
 		alg:        model.ES256,
@@ -54,7 +54,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	ecdsaPublicKey, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*ecdsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*ecdsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: ecdsaPublicKey,
@@ -79,7 +79,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA256 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	if opts == nil || opts.HashFunc() == 0 {
@@ -100,7 +100,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 
 	r, s, err := common.ExtractRSFromSignature(signature, keySize)
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature", e.InvalidSignature)
+		return false, fmt.Errorf("%winvalid signature", e.ErrInvalidSignature)
 	}
 
 	return ecdsa.Verify(validator.publicKey, bodyHash[:], r, s), nil

--- a/internal/algorithms/es384/ES384.go
+++ b/internal/algorithms/es384/ES384.go
@@ -29,7 +29,7 @@ func NewSigner() (*Signer, error) {
 	curve := elliptic.P384()
 	pk, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.ES384,
@@ -40,10 +40,10 @@ func NewSigner() (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	ecdsaPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*ecdsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*ecdsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	if ecdsaPrivateKey.Curve.Params().Name != curveName {
-		return nil, fmt.Errorf("%winvalid key provided - curve should be %s, was %s", e.InvalidPrivateKey, curveName, ecdsaPrivateKey.Curve.Params().Name)
+		return nil, fmt.Errorf("%wcurve should be %s, was %s", e.ErrInvalidPrivateKey, curveName, ecdsaPrivateKey.Curve.Params().Name)
 	}
 	return &Signer{
 		alg:        model.ES384,
@@ -54,7 +54,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	ecdsaPublicKey, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*ecdsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*ecdsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: ecdsaPublicKey,
@@ -79,7 +79,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA384 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	if opts == nil || opts.HashFunc() == 0 {
@@ -100,7 +100,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 
 	r, s, err := common.ExtractRSFromSignature(signature, keySize)
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature", e.InvalidSignature)
+		return false, fmt.Errorf("%winvalid signature", e.ErrInvalidSignature)
 	}
 
 	return ecdsa.Verify(validator.publicKey, bodyHash[:], r, s), nil

--- a/internal/algorithms/es512/ES512.go
+++ b/internal/algorithms/es512/ES512.go
@@ -29,7 +29,7 @@ func NewSigner() (*Signer, error) {
 	curve := elliptic.P521()
 	pk, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.ES512,
@@ -40,10 +40,10 @@ func NewSigner() (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	ecdsaPrivateKey, ok := privateKey.(*ecdsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*ecdsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*ecdsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	if ecdsaPrivateKey.Curve.Params().Name != curveName {
-		return nil, fmt.Errorf("%winvalid key provided - curve should be %s, was %s", e.InvalidPrivateKey, curveName, ecdsaPrivateKey.Curve.Params().Name)
+		return nil, fmt.Errorf("%wcurve should be %s, was %s", e.ErrInvalidPrivateKey, curveName, ecdsaPrivateKey.Curve.Params().Name)
 	}
 	return &Signer{
 		alg:        model.ES512,
@@ -54,7 +54,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	ecdsaPublicKey, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*ecdsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*ecdsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: ecdsaPublicKey,
@@ -79,7 +79,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA512 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	if opts == nil || opts.HashFunc() == 0 {
@@ -100,7 +100,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 
 	r, s, err := common.ExtractRSFromSignature(signature, keySize)
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature", e.InvalidSignature)
+		return false, fmt.Errorf("%winvalid signature", e.ErrInvalidSignature)
 	}
 
 	return ecdsa.Verify(validator.publicKey, bodyHash[:], r, s), nil

--- a/internal/algorithms/ps256/PS256.go
+++ b/internal/algorithms/ps256/PS256.go
@@ -27,7 +27,7 @@ func NewSigner(size int) (*Signer, error) {
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.PS256,
@@ -38,7 +38,7 @@ func NewSigner(size int) (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	return &Signer{
 		alg:        model.PS256,
@@ -49,7 +49,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: rsaPublicKey,
@@ -74,7 +74,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA256 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	var hashedDigest []byte
@@ -104,7 +104,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 	err := rsa.VerifyPSS(validator.publicKey, crypto.SHA256, hashedDigest[:], signature, opts)
 
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature: %s", e.InvalidSignature, err.Error())
+		return false, fmt.Errorf("%winvalid signature: %s", e.ErrInvalidSignature, err.Error())
 	}
 
 	return true, nil

--- a/internal/algorithms/ps384/PS384.go
+++ b/internal/algorithms/ps384/PS384.go
@@ -27,7 +27,7 @@ func NewSigner(size int) (*Signer, error) {
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.PS384,
@@ -38,7 +38,7 @@ func NewSigner(size int) (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	return &Signer{
 		alg:        model.PS384,
@@ -49,7 +49,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: rsaPublicKey,
@@ -74,7 +74,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA384 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	var hashedDigest []byte
@@ -104,7 +104,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 	err := rsa.VerifyPSS(validator.publicKey, crypto.SHA384, hashedDigest[:], signature, opts)
 
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature: %s", e.InvalidSignature, err.Error())
+		return false, fmt.Errorf("%winvalid signature: %s", e.ErrInvalidSignature, err.Error())
 	}
 
 	return true, nil

--- a/internal/algorithms/ps512/PS512.go
+++ b/internal/algorithms/ps512/PS512.go
@@ -27,7 +27,7 @@ func NewSigner(size int) (*Signer, error) {
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.PS512,
@@ -38,7 +38,7 @@ func NewSigner(size int) (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	return &Signer{
 		alg:        model.PS512,
@@ -49,7 +49,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: rsaPublicKey,
@@ -74,7 +74,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA512 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	var hashedDigest []byte
@@ -104,7 +104,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 	err := rsa.VerifyPSS(validator.publicKey, crypto.SHA512, hashedDigest[:], signature, opts)
 
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature: %s", e.InvalidSignature, err.Error())
+		return false, fmt.Errorf("%winvalid signature: %s", e.ErrInvalidSignature, err.Error())
 	}
 
 	return true, nil

--- a/internal/algorithms/rs256/RS256.go
+++ b/internal/algorithms/rs256/RS256.go
@@ -27,7 +27,7 @@ func NewSigner(size int) (*Signer, error) {
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.RS256,
@@ -38,7 +38,7 @@ func NewSigner(size int) (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	return &Signer{
 		alg:        model.RS256,
@@ -49,7 +49,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: rsaPublicKey,
@@ -74,7 +74,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA256 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	var hashedDigest []byte
@@ -100,7 +100,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 	err := rsa.VerifyPKCS1v15(validator.publicKey, crypto.SHA256, hashedDigest[:], signature)
 
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature: %s", e.InvalidSignature, err.Error())
+		return false, fmt.Errorf("%winvalid signature: %s", e.ErrInvalidSignature, err.Error())
 	}
 
 	return true, nil

--- a/internal/algorithms/rs384/RS384.go
+++ b/internal/algorithms/rs384/RS384.go
@@ -27,7 +27,7 @@ func NewSigner(size int) (*Signer, error) {
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.RS384,
@@ -38,7 +38,7 @@ func NewSigner(size int) (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	return &Signer{
 		alg:        model.RS384,
@@ -49,7 +49,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: rsaPublicKey,
@@ -74,7 +74,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA384 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	var hashedDigest []byte
@@ -100,7 +100,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 	err := rsa.VerifyPKCS1v15(validator.publicKey, crypto.SHA384, hashedDigest[:], signature)
 
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature: %s", e.InvalidSignature, err.Error())
+		return false, fmt.Errorf("%winvalid signature: %s", e.ErrInvalidSignature, err.Error())
 	}
 
 	return true, nil

--- a/internal/algorithms/rs512/RS512.go
+++ b/internal/algorithms/rs512/RS512.go
@@ -27,7 +27,7 @@ func NewSigner(size int) (*Signer, error) {
 	}
 	pk, err := rsa.GenerateKey(rand.Reader, size)
 	if err != nil {
-		return nil, fmt.Errorf("%wfailed to generate key: %s", e.SigningError, err.Error())
+		return nil, fmt.Errorf("%wfailed to generate key: %s", e.ErrSigning, err.Error())
 	}
 	return &Signer{
 		alg:        model.RS512,
@@ -38,7 +38,7 @@ func NewSigner(size int) (*Signer, error) {
 func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 	rsaPrivateKey, ok := privateKey.(*rsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.Privatekey`", e.InvalidPrivateKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.Privatekey`", e.ErrInvalidPrivateKey)
 	}
 	return &Signer{
 		alg:        model.RS512,
@@ -49,7 +49,7 @@ func NewSignerFromPrivateKey(privateKey crypto.PrivateKey) (*Signer, error) {
 func NewValidator(publicKey crypto.PublicKey) (*Validator, error) {
 	rsaPublicKey, ok := publicKey.(*rsa.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("%winvalid key provided - should be instance of `*rsa.PublicKey`", e.InvalidPublicKey)
+		return nil, fmt.Errorf("%wshould be instance of `*rsa.PublicKey`", e.ErrInvalidPublicKey)
 	}
 	return &Validator{
 		publicKey: rsaPublicKey,
@@ -74,7 +74,7 @@ func (signer *Signer) Public() crypto.PublicKey {
 
 func (signer *Signer) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
 	if opts != nil && opts.HashFunc() > 0 && opts.HashFunc() != crypto.SHA512 {
-		return nil, fmt.Errorf("%winvalid hash function provided for specified signer", e.SigningError)
+		return nil, fmt.Errorf("%winvalid hash function for this algorithm", e.ErrSigning)
 	}
 
 	var hashedDigest []byte
@@ -100,7 +100,7 @@ func (validator *Validator) ValidateSignature(digest, signature []byte) (bool, e
 	err := rsa.VerifyPKCS1v15(validator.publicKey, crypto.SHA512, hashedDigest[:], signature)
 
 	if err != nil {
-		return false, fmt.Errorf("%winvalid signature: %s", e.InvalidSignature, err.Error())
+		return false, fmt.Errorf("%winvalid signature: %s", e.ErrInvalidSignature, err.Error())
 	}
 
 	return true, nil

--- a/jwk/jwk.go
+++ b/jwk/jwk.go
@@ -37,7 +37,7 @@ func PublicJwk(publicKey crypto.PublicKey) (*map[string]any, error) {
 		return &m, nil
 	}
 
-	return nil, fmt.Errorf("%wunknown public key format provided", e.InvalidPublicKey)
+	return nil, fmt.Errorf("%wunknown format", e.ErrInvalidPublicKey)
 }
 
 func PrivateJwk(privateKey crypto.PrivateKey) (*map[string]any, error) {
@@ -53,5 +53,5 @@ func PrivateJwk(privateKey crypto.PrivateKey) (*map[string]any, error) {
 		return &m, nil
 	}
 
-	return nil, fmt.Errorf("%wunknown private key format provided", e.InvalidPrivateKey)
+	return nil, fmt.Errorf("%wunknown format", e.ErrInvalidPrivateKey)
 }

--- a/jws/signature.go
+++ b/jws/signature.go
@@ -73,7 +73,7 @@ func GetSigner(alg model.Algorithm, opts *model.Opts) (model.Signer, error) {
 		s, err = hs512.NewSigner(opts.SecretKey)
 
 	default:
-		return nil, fmt.Errorf("%wunsupported algorithm: '%s'", e.UnsupportedAlgorithm, alg)
+		return nil, fmt.Errorf("%w'%s'", e.ErrUnsupportedAlgorithm, alg)
 	}
 
 	return s, err
@@ -110,10 +110,10 @@ func GetSignerFromPrivateKey(alg model.Algorithm, privateKey crypto.PrivateKey) 
 	case model.PS512:
 		s, err = ps512.NewSignerFromPrivateKey(privateKey)
 	case model.HS256, model.HS384, model.HS512:
-		return nil, fmt.Errorf("%wHMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function", e.UnsupportedAlgorithm)
+		return nil, fmt.Errorf("%wHMAC Signers cannot be created this way - please use GetSigner and specify the secret key using the Opts function", e.ErrUnsupportedAlgorithm)
 
 	default:
-		return nil, fmt.Errorf("%wunsupported algorithm: '%s'", e.UnsupportedAlgorithm, alg)
+		return nil, fmt.Errorf("%w'%s'", e.ErrUnsupportedAlgorithm, alg)
 	}
 
 	return s, err

--- a/jws/validate.go
+++ b/jws/validate.go
@@ -46,9 +46,9 @@ func GetValidator(alg model.Algorithm, publicKey crypto.PublicKey) (model.Valida
 	case model.PS512:
 		v, err = ps512.NewValidator(publicKey)
 	case model.HS256, model.HS384, model.HS512:
-		return nil, fmt.Errorf("%wvalidators cannot be created for symmetric algorithms", e.UnsupportedAlgorithm)
+		return nil, fmt.Errorf("%wvalidators cannot be created for symmetric algorithms", e.ErrUnsupportedAlgorithm)
 	default:
-		return nil, fmt.Errorf("%wunsupported algorithm: '%s'", e.UnsupportedAlgorithm, alg.String())
+		return nil, fmt.Errorf("%w'%s'", e.ErrUnsupportedAlgorithm, alg.String())
 	}
 	return v, err
 }
@@ -83,9 +83,9 @@ func GetValidatorFromJwk(alg model.Algorithm, jwk []byte) (model.Validator, erro
 	case model.PS512:
 		v, err = ps512.NewValidatorFromJwk(jwk)
 	case model.HS256, model.HS384, model.HS512:
-		return nil, fmt.Errorf("%wvalidators cannot be created for symmetric algorithms", e.UnsupportedAlgorithm)
+		return nil, fmt.Errorf("%wvalidators cannot be created for symmetric algorithms", e.ErrUnsupportedAlgorithm)
 	default:
-		return nil, fmt.Errorf("%wunsupported algorithm: '%s'", e.UnsupportedAlgorithm, alg.String())
+		return nil, fmt.Errorf("%w'%s'", e.ErrUnsupportedAlgorithm, alg.String())
 	}
 	return v, err
 }

--- a/model/model.go
+++ b/model/model.go
@@ -6,12 +6,27 @@ import (
 	"strings"
 )
 
+// Signer signs JWS payloads per RFC 7515 / RFC 7518.
+//
+// The Sign method follows JOSE conventions rather than Go's crypto.Signer contract.
+// It supports two modes:
+//   - JOSE mode (opts == nil or opts.HashFunc() == 0): digest is the raw JWS Signing Input
+//     and the implementation hashes it internally using the algorithm's designated hash.
+//     This is the expected usage for JWS operations per RFC 7518.
+//   - Pre-hashed mode (opts.HashFunc() != 0): digest is already hashed by the caller
+//     and the implementation skips internal hashing. This supports interoperability with
+//     callers following Go's crypto.Signer convention.
 type Signer interface {
 	Alg() Algorithm
 	Public() crypto.PublicKey
 	Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error)
 }
 
+// Validator verifies JWS signatures per RFC 7515 / RFC 7518.
+//
+// ValidateSignature expects the raw JWS Signing Input as digest (not pre-hashed).
+// The implementation hashes it internally using the algorithm's designated hash
+// before performing verification.
 type Validator interface {
 	ValidateSignature(digest, signature []byte) (bool, error)
 	Public() crypto.PublicKey
@@ -102,11 +117,16 @@ func algorithm(a Algorithm) *Algorithm {
 	return &a
 }
 
+// Opts configures key generation for new signers.
+// BitSize applies to RSA algorithms. SecretKey applies to HMAC algorithms.
 type Opts struct {
 	BitSize   int
 	SecretKey *[]byte
 }
 
+// SignerOpts implements crypto.SignerOpts and is used to signal that the digest
+// passed to Sign has already been hashed. When provided with a non-zero Hash,
+// the signer will skip internal hashing.
 type SignerOpts struct {
 	Hash crypto.Hash
 }


### PR DESCRIPTION
## Summary
- **Signing contract documentation** — clarify Signer's dual-mode behaviour (JOSE raw input when opts=nil vs pre-hashed when opts provided) and Validator's raw input expectation, on the interface definitions in `model/model.go`
- **Error naming** — rename error vars to follow Go `ErrFoo` convention (`InvalidPublicKey` → `ErrInvalidPublicKey`, etc.) with meaningful prefixes. All call sites and test assertions updated for grammatical consistency.
- **README** — add RFC references, add signing contract section, fix typo in validator example
- **Pre-commit** — bump golangci-lint from v1.55.2 to v2.11.4, pre-commit-hooks from v4.4.0 to v6.0.0

## Breaking changes
Error variable names are renamed. Consumers matching on these errors by name will need to update:
- `InvalidPublicKey` → `ErrInvalidPublicKey`
- `InvalidPrivateKey` → `ErrInvalidPrivateKey`
- `InvalidSignature` → `ErrInvalidSignature`
- `UnsupportedAlgorithm` → `ErrUnsupportedAlgorithm`
- `SigningError` → `ErrSigning`

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] golangci-lint passes with updated pre-commit config